### PR TITLE
Updated for use in packages

### DIFF
--- a/R/doRNG.R
+++ b/R/doRNG.R
@@ -162,7 +162,7 @@ doRNG <- function (obj, ex, envir, data){
     # directly register (temporarly) the computing backend
 	on.exit({setDoBackend(rngBackend)}, add=TRUE)
 	setDoBackend(rngBackend$data$backend)
-	do.call('%dorng%', list(obj, ex), envir=parent.frame())
+	do.call('%dorng%', list(obj, ex), envir=envir)
 }
 
 ##% Get/Sets the registered foreach backend's data


### PR DESCRIPTION
I am working on a patch for a genetics algorithm package, luca-scr/GA#2, introducing reproducible seeds to auto-generated nodes. I am planning to use doRNG.

As part of debugging that process, I found one line that prevents doRNG from being used within a package. The `doRNG()` wrapper receives `envir` as an argument and then provides `parent.frame()` as its argument to `%dopar%`. This works when doRNG is being used in an interactive session, but it doesn't play nice in a package's managed namespace. The patch simply passes `envir` down to `%dopar%`.